### PR TITLE
Fix out of index error

### DIFF
--- a/internal/router/chat.go
+++ b/internal/router/chat.go
@@ -367,7 +367,9 @@ func compressMsg(client *openai.Client, messages []ChatCompletionMessage, b *bot
 		if msg.Role == ChatMessageRoleSystem {
 			//isolate past history from the system message
 			pastHistory := strings.Split(msg.Content, "Here is the summary of your conversation history with the user previously:")
-			flattenedContent.WriteString(fmt.Sprintf("System: %s\n", pastHistory[1]))
+			if len(pastHistory) >= 2 {
+				flattenedContent.WriteString(fmt.Sprintf("System: %s\n", pastHistory[1]))
+			}
 			continue // Skip system messages for compression
 		}
 		flattenedContent.WriteString(fmt.Sprintf("%s: %s\n", msg.Role, msg.Content))


### PR DESCRIPTION
This pull request introduces a small but important fix to the `compressMsg` function in `internal/router/chat.go`. The change ensures that the code only attempts to access the summary portion of a system message if it actually exists, preventing potential out-of-bounds errors.

- Reliability improvement:
  * Added a check to ensure `pastHistory[1]` is only accessed if the split result has at least two elements, preventing possible panics when processing system messages in `compressMsg`.