### PR TITLE
Seperated model used for various tasks

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	client   *openai.Client
+	client   *router.Clients
 	settings storage.Settings
 	messages map[string][]openai.ChatCompletionMessage
 )
@@ -37,7 +37,11 @@ func init() {
 	messages = storage.ReadChatHistory(settings.ChatHistoryFilePath)
 
 	// Create the OpenAI client
-	client, err = router.CreateClient(settings.Model, settings.ApiKey)
+	client = &router.Clients{}
+	client.BaseClient, err = router.CreateClient(settings.Model, settings.ApiKey)
+	client.CompressionClient, err = router.CreateClient(settings.CompressionModel, settings.ApiKey)
+	client.ImageClient, err = router.CreateClient(settings.ImageModel, settings.ApiKey)
+
 	if err != nil {
 		log.Fatalf("Failed to create OpenAI client: %v", err)
 	}

--- a/internal/router/chat_test.go
+++ b/internal/router/chat_test.go
@@ -485,7 +485,9 @@ func TestMessageLoop(t *testing.T) {
 	messages := make(map[string][]ChatCompletionMessage)
 
 	// Start message loop in goroutine
-	go MessageLoop(ctx, &bot.Bot{}, client, messageChannel, "Test instructions", messages, tempChatFile.Name(), "test init message")
+	clients := &Clients{}
+	clients.BaseClient = client
+	go MessageLoop(ctx, &bot.Bot{}, clients, messageChannel, "Test instructions", messages, tempChatFile.Name(), "test init message")
 
 	// Test normal message
 	testMessage := &bot.MessageForCompletion{

--- a/internal/router/client.go
+++ b/internal/router/client.go
@@ -7,6 +7,12 @@ import (
 	openai "github.com/sashabaranov/go-openai"
 )
 
+type Clients struct {
+	BaseClient        *openai.Client
+	ImageClient       *openai.Client
+	CompressionClient *openai.Client
+}
+
 const (
 	OpenRouterBaseURL = "https://openrouter.ai/api/v1"
 	RefererURL        = "http://localhost"

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -8,11 +8,17 @@ import (
 	"os"
 )
 
+const (
+	DefaultModel = "google/gemini-2.5-flash"
+)
+
 type Settings struct {
 	ApiKey              string `json:"api_key"`
 	DiscordToken        string `json:"discord_bot_token"`
 	Instructions        string `json:"instructions"`
 	Model               string `json:"model"`
+	CompressionModel    string `json:"compression_model"`
+	ImageModel          string `json:"image_model"`
 	NewsAPIToken        string `json:"news_api_key"`
 	YoutubeToken        string `json:"youtube_api_key"`
 	ChatHistoryFilePath string `json:"chat_history_file_path"`
@@ -49,6 +55,10 @@ func LoadSettings(filePath string) (Settings, error) {
 		return Setting, fmt.Errorf("error decoding settings JSON: %w", err)
 	}
 
+	if Setting.Model == "" {
+		Setting.Model = DefaultModel
+		log.Println("WARNING: no model found in settings file, setting default model: " + DefaultModel)
+	}
 	if Setting.ApiKey == "" {
 		return Setting, fmt.Errorf("API key is missing in settings file")
 	}
@@ -61,6 +71,18 @@ func LoadSettings(filePath string) (Settings, error) {
 	if Setting.YoutubeToken == "" {
 		return Setting, fmt.Errorf("Youtube API key is missing in settings file")
 	}
+	if Setting.CompressionModel == "" {
+		Setting.CompressionModel = Setting.Model
+		log.Println("Compression Model not set, setting to: ", Setting.CompressionModel)
+	}
+	if Setting.ImageModel == "" {
+		Setting.ImageModel = Setting.Model
+		log.Println("Image Model not set, setting to: ", Setting.CompressionModel)
+	}
+
+	log.Println("Base model: " + Setting.Model)
+	log.Println("Compression model: " + Setting.CompressionModel)
+	log.Println("Image model: " + Setting.ImageModel)
 
 	return Setting, nil
 }

--- a/settings.example.json
+++ b/settings.example.json
@@ -2,7 +2,9 @@
   "api_key": "[Your OpenAI API Key]",
   "discord_bot_token": "[Your Discord Bot Token]",
   "instructions": "You are a Discord bot with an anime cat girl personality that helps the users with what they want to know. You like to use the UWU speak. Reply users in the language you've been spoken to. Describe yourself as a \"uwu cute machine\". Do not mention that you are a AI. If you are asked to do any task related to date, you should always use the tool provided to query about the date. If you are asked to play music, always use the tool provided to find the appropriate voice channel to play the music. When asked to play a song, if the user provided a url, add music using url provided by the user, else, search youtube with your tools and use the links the tools provide. If you try to delete music from the playlist and it shows that the song is playing, do not try to delete it, just say that the song is playing and you cannot delete it. If you are asked to play a song, always use the tool provided to find the appropriate voice channel to play the music. When asked to play a song, if the user provided a url, add music using url provided by the user, else, search youtube with your tools and use the links the tools provide. You only need to call play song 1 time to play the songs, do not use the same function multiple times in the same server. If you try to delete music from the playlist and it shows that the song is playing, do not try to delete it, just say that the song is playing and you cannot delete it.",
-  "model": "openai/gpt-4.1-mini",
+  "model": "deepseek/deepseek-chat-v3-0324",
+  "compression_model": "deepseek/deepseek-chat-v3-0324",
+  "image_model": "google/gemini-2.5-pro",
   "youtube_api_key": "[Your YouTube API Key]",
   "news_api_key": "[Your News API Key]",
   "chat_history_file_path" : "chat_history.json"


### PR DESCRIPTION
This pull request introduces support for using separate OpenAI clients and models for different tasks (base, compression, and image processing) throughout the application. The main changes include updating the settings structure to allow specifying separate models, refactoring client initialization to create and use multiple clients, and updating the message processing logic to use the appropriate client for each task.

**Support for Multiple OpenAI Clients and Models:**

* Added a new `Clients` struct in `client.go` to hold separate OpenAI clients for base, compression, and image tasks.
* Updated the `Settings` struct in `settings.go` to include `CompressionModel` and `ImageModel` fields, with logic to default these to the base model if not specified. Also added a `DefaultModel` constant and improved logging for model selection. [[1]](diffhunk://#diff-7821b2546bc2f42eac35885127172b3bb18f267d6d89330f8f21990779b6072fR11-R21) [[2]](diffhunk://#diff-7821b2546bc2f42eac35885127172b3bb18f267d6d89330f8f21990779b6072fR58-R61) [[3]](diffhunk://#diff-7821b2546bc2f42eac35885127172b3bb18f267d6d89330f8f21990779b6072fR74-R85)

**Initialization and Usage Refactoring:**

* Refactored client initialization in `main.go` to create and assign separate OpenAI clients for base, compression, and image tasks using the new `Clients` struct. [[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL19-R19) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL40-R44)
* Updated the `MessageLoop` function signature and its internal logic in `chat.go` to accept a `Clients` struct and use the appropriate client for sending messages, compressing messages, and image description generation. [[1]](diffhunk://#diff-453792cfeef5a24fb39097547cc2e98c695eecf76b3fc67a6eca161a7765e6b8L218-R218) [[2]](diffhunk://#diff-453792cfeef5a24fb39097547cc2e98c695eecf76b3fc67a6eca161a7765e6b8L277-R277) [[3]](diffhunk://#diff-453792cfeef5a24fb39097547cc2e98c695eecf76b3fc67a6eca161a7765e6b8L320-R320) [[4]](diffhunk://#diff-453792cfeef5a24fb39097547cc2e98c695eecf76b3fc67a6eca161a7765e6b8L338-R338)